### PR TITLE
Feat/improved import system

### DIFF
--- a/src/Fixen/CodeGen/Import.hs
+++ b/src/Fixen/CodeGen/Import.hs
@@ -56,7 +56,10 @@ codeGenImports prog =
 codeGenImportStmt :: HsImport -> Text
 codeGenImportStmt i =
   let n = i ^. moduleName
-   in Text.concat ["import ", fullIdentifier n]
+   in Text.concat [ "import "
+                  , if hsImportQualified i then "qualified " else ""
+                  , fullIdentifier n
+                  , maybe "" (\a -> Text.concat [" as ", fullIdentifier a]) (hsImportAlias i)]
 
 -- | The import statements that are always produced by the Fixen compiler.
 --

--- a/src/Fixen/CodeGen/Import.hs
+++ b/src/Fixen/CodeGen/Import.hs
@@ -59,7 +59,9 @@ codeGenImportStmt i =
    in Text.concat [ "import "
                   , if hsImportQualified i then "qualified " else ""
                   , fullIdentifier n
-                  , maybe "" (\a -> Text.concat [" as ", fullIdentifier a]) (hsImportAlias i)]
+                  , maybe "" (\a -> Text.concat [" as ", fullIdentifier a]) (hsImportAlias i)
+                  , maybe "" (Text.cons ' ') (hsImportSpecs i)
+                  ]
 
 -- | The import statements that are always produced by the Fixen compiler.
 --

--- a/src/Fixen/IR/AST.hs
+++ b/src/Fixen/IR/AST.hs
@@ -991,6 +991,14 @@ data HsImport = HsImport
   -- ^ The imported module name (e.g. @Data.List@).
   --
   -- @since 0.0.1
+  , hsImportQualified :: Bool
+  -- ^ Whether this is a qualified import
+  --
+  -- @since 0.0.1
+  , hsImportAlias :: Maybe ModuleName
+  -- ^ The alias for the import, if it exists
+  --
+  -- @since 0.0.1
   }
   deriving (Show, Eq)
 
@@ -1925,8 +1933,17 @@ prettyProgram
 --
 --   Output format: @Data.List (42)@
 prettyHsImport :: HsImport -> Doc ann
-prettyHsImport HsImport {hsImportNodeId = p, hsImportModuleName = module_name} =
-  pretty (fullIdentifier module_name) <+> (lparen <> pretty p <> rparen)
+prettyHsImport HsImport {hsImportNodeId = p, hsImportQualified = q, hsImportModuleName = module_name, hsImportAlias = alias} =
+    let qualified_doc =
+          if q then pretty ("qualified " :: Text) else mempty
+        alias_doc =
+          case alias of
+            Nothing -> mempty
+            Just a -> pretty (" as " :: Text) <> pretty (fullIdentifier a)
+     in qualified_doc
+          <> pretty (fullIdentifier module_name)
+          <> alias_doc
+          <+> (lparen <> pretty p <> rparen)
 
 -- | Pretty-print a 'HsBlock' node.
 --

--- a/src/Fixen/IR/AST.hs
+++ b/src/Fixen/IR/AST.hs
@@ -999,6 +999,10 @@ data HsImport = HsImport
   -- ^ The alias for the import, if it exists
   --
   -- @since 0.0.1
+  , hsImportSpecs :: Maybe Text
+  -- ^ The explicit import specifications, if it exists.
+  --
+  -- @since 0.0.1
   }
   deriving (Show, Eq)
 
@@ -1928,21 +1932,26 @@ prettyProgram
 
 -- | Pretty-print a 'HsImport' node.
 --
---   Renders the imported module name followed by its 'NodeId' in
---   parentheses.
+--   Renders the imported module name, optional import modifiers, optional
+--   explicit import specifications, and the import's 'NodeId' in parentheses.
 --
---   Output format: @Data.List (42)@
+--   Output format: @qualified Data.Map as Map (Map) (42)@
 prettyHsImport :: HsImport -> Doc ann
-prettyHsImport HsImport {hsImportNodeId = p, hsImportQualified = q, hsImportModuleName = module_name, hsImportAlias = alias} =
+prettyHsImport HsImport {hsImportNodeId = p, hsImportQualified = q, hsImportModuleName = module_name, hsImportAlias = alias, hsImportSpecs = specs} =
     let qualified_doc =
           if q then pretty ("qualified " :: Text) else mempty
         alias_doc =
           case alias of
             Nothing -> mempty
             Just a -> pretty (" as " :: Text) <> pretty (fullIdentifier a)
+        specs_doc =
+          case specs of
+            Nothing -> mempty
+            Just s -> pretty (" " :: Text) <> pretty s
      in qualified_doc
           <> pretty (fullIdentifier module_name)
           <> alias_doc
+          <> specs_doc
           <+> (lparen <> pretty p <> rparen)
 
 -- | Pretty-print a 'HsBlock' node.

--- a/src/Fixen/ModuleSystem.hs
+++ b/src/Fixen/ModuleSystem.hs
@@ -251,9 +251,11 @@ combineProgram in_prog new_prog =
       new_rels = new_prog ^. relationDeclarations
       new_partial_ords = new_prog ^. partialOrdDeclarations
       new_lattices = new_prog ^. latticeDeclarations
-      import_key x = ( fullIdentifier (x ^. moduleName)
+      import_key x = 
+        ( fullIdentifier (x ^. moduleName)
         , hsImportQualified x
         , fullIdentifier <$> hsImportAlias x
+        , hsImportSpecs x
         )
       old_import_set =
         -- Build a set of already-imported module identifiers for deduplication.

--- a/src/Fixen/ModuleSystem.hs
+++ b/src/Fixen/ModuleSystem.hs
@@ -251,13 +251,17 @@ combineProgram in_prog new_prog =
       new_rels = new_prog ^. relationDeclarations
       new_partial_ords = new_prog ^. partialOrdDeclarations
       new_lattices = new_prog ^. latticeDeclarations
+      import_key x = ( fullIdentifier (x ^. moduleName)
+        , hsImportQualified x
+        , fullIdentifier <$> hsImportAlias x
+        )
       old_import_set =
         -- Build a set of already-imported module identifiers for deduplication.
-        Set.fromList (in_prog ^. imports ^.. each . moduleName <&> fullIdentifier)
+        Set.fromList (import_key <$> (in_prog ^. imports))
       -- Filter new imports to exclude any that already exist in the old program.
       new_imports =
         filter
-          (\x -> fullIdentifier (x ^. moduleName) `Set.notMember` old_import_set)
+          (\x -> import_key x `Set.notMember` old_import_set)
           (new_prog ^. imports)
       new_hs_blocks = new_prog ^. hsBlocks
       new_queries = new_prog ^. queries

--- a/src/Fixen/Parser.hs
+++ b/src/Fixen/Parser.hs
@@ -35,7 +35,7 @@ import Data.List.NonEmpty
 import Data.Map.Strict qualified as Map
 import Data.Proxy
 import Data.Set qualified as Set
-import Data.Text (Text, unpack)
+import Data.Text (Text, pack, unpack)
 import Error.Diagnose.Compat.Megaparsec (errorDiagnosticFromBundle)
 import Fixen.Fields
 import Fixen.IR.AST
@@ -945,6 +945,31 @@ parseInclude = parsePositioned $ do
   i <- getNewNodeId
   return $ Include i include_path
 
+-- ** Explicit Import Specifications Parser
+--
+-- | Parses the specifications in an explicit import
+--
+-- @
+-- import Data.Map (Map)
+-- @
+parseImportSpecs :: Parser σ Text
+parseImportSpecs = pack <$> parens
+-- Convert String returned from parens back into Text
+  where
+    parens = do
+      -- Parse the opening parens
+      _ <- C.char '('
+      -- Parse chunks until the closing parens is hit
+      chunks <- P.manyTill chunk (C.char ')')
+      -- Return the resulting string enclosed by parens
+      return $ "(" <> concat chunks <> ")"
+
+    chunk =
+      -- Try to parse a nested parens group
+      P.try parens
+        -- Otherwise, parse a character that is not ')', and convert it to a single element list
+        <|> ((: []) <$> P.satisfy (/= ')'))
+
 -- ** Import-Statement Parser
 
 -- | Parses an import statement:
@@ -991,9 +1016,18 @@ parseImport = parsePositioned $ do
               parseModuleName
           )
 
+  -- Parse explicit import specifications if it exists
+  importSpecs <-
+    either (const Nothing) Just
+      <$> P.observing
+        ( P.try $ do
+            _ <- indented
+            parseImportSpecs
+        )
+
   -- Allocate a fresh node ID and construct the HsImport AST node
   i <- getNewNodeId
-  return $ HsImport i mod_name qualifiedImport alias
+  return $ HsImport i mod_name qualifiedImport alias importSpecs
 
 -- ** Phases-Declaration Parsers
 

--- a/src/Fixen/Parser.hs
+++ b/src/Fixen/Parser.hs
@@ -966,13 +966,34 @@ parseImport = parsePositioned $ do
   -- Parse the 'import' keyword (must not be indented)
   -- Need 'try' since import is among many top-level alternatives
   _ <- P.try $ l $ L.nonIndented sc $ keyword "import"
+  -- Verify proper indentation before the qualified keyword
+  _ <- indented
+
+  -- Parse the 'qualified' keyword if it exists
+  qualifiedImport <-
+      either (const False) (const True)
+        <$> P.observing (P.try (l $ keyword "qualified"))
+
   -- Verify proper indentation before the module name
   _ <- indented
+
   -- Parse the Haskell module name (e.g. Data.List, MyCompany.MyModule)
   mod_name <- parseModuleName
+
+  -- Parse the import alias if it exists
+  alias <-
+      either (const Nothing) Just
+        <$> P.observing
+          ( P.try $ do
+              _ <- indented
+              _ <- l $ keyword "as"
+              _ <- indented
+              parseModuleName
+          )
+
   -- Allocate a fresh node ID and construct the HsImport AST node
   i <- getNewNodeId
-  return $ HsImport i mod_name
+  return $ HsImport i mod_name qualifiedImport alias
 
 -- ** Phases-Declaration Parsers
 


### PR DESCRIPTION
Add support for qualified import and explicit imports, the following import statements should now parse properly and the code generation and pretty printing should work appropriately.

Qualified imports:
```hs
import qualified Data.List
```
Qualified imports with aliases
```hs
import qualified Data.List as List
```
Explicit imports
```hs
import Data.List (nub, sort)
```
Explicit type imports with all data constructors
```hs
import Data.Maybe (Maybe(..))
```
Qualified imports with explicit specifications
```hs
import qualified Data.List as L (sort)
```