### PR TITLE
Demos/reaching definitions

### DIFF
--- a/demos/StaticAnalysis/Common.fix
+++ b/demos/StaticAnalysis/Common.fix
@@ -5,15 +5,17 @@ import Algebra.PartialOrd
 import GHC.Generics
 import Control.DeepSeq
 import Data.Hashable
+import Data.List
 
 ```hs
-data Expr = Id String | InputE | Num Int | Plus Expr Expr | Leq Expr Expr | Gte Expr Expr | Eq Expr Expr
+data Expr = Id String | InputE | Num Int | Plus Expr Expr | Times Expr Expr | Leq Expr Expr | Gte Expr Expr | Eq Expr Expr
     deriving (Eq, Show, Generic)
 
 instance NFData Expr where
     rnf (Id x) = rnf x
     rnf (Num x) = rnf x
     rnf (Plus e e') = rnf (e, e')
+    rnf (Times e e') = rnf (e, e')
     rnf (Leq e e') = rnf (e, e')
     rnf (Gte e e') = rnf (e, e')
     rnf (Eq e e') = rnf (e, e')
@@ -30,7 +32,7 @@ instance PartialOrd Expr where
 mainTest :: [Fact]
 mainTest = [
   -- V = 1
-  Var 0 "V", Seq 0 1,
+  Var 0 "V", Seq 0 2,
   Assign 2 "V" (Num 1), Seq 2 4,
   -- while V <= 10
   Branch 4 (Leq (Id "V") (Num 9)) 5 6,
@@ -40,6 +42,19 @@ mainTest = [
   Assign 7 "V" (Num 0), Seq 7 101,
   -- end
   Var 101 "END"
+  ]
+
+factorialTest :: [Fact]
+factorialTest = [
+  Var 0 "Y", Seq 0 1,
+  Var 1 "Z", Seq 1 2,
+  Assign 2 "Y" (Id "X"), Seq 2 3,
+  Assign 3 "Z" (Num 1), Seq 3 4,
+  Branch 4 (Gte (Id "Y") (Num 1)) 5 7,
+  Assign 5 "Z" (Times (Id "Z") (Id "Y")), Seq 5 6,
+  Assign 6 "Y" (Plus (Id "Y") (Num (-1))), Seq 6 4,
+  Assign 7 "Y" (Num 0), Seq 7 100,
+  Var 100 "END"
   ]
 ```
 

--- a/demos/StaticAnalysis/Interval.fix
+++ b/demos/StaticAnalysis/Interval.fix
@@ -1,5 +1,5 @@
 -- put this in benchmarks/ReducedProduct/Interval.hs
-module ReducedProduct.FixenNoPriorities where
+module Main where
 
 include "Common"
 
@@ -112,9 +112,11 @@ evalI e st = case e of
     Plus e1 e2 -> case (evalI e1 st, evalI e2 st) of
         (Pair (a, b), Pair (c, d)) -> Pair (a + c, b + d)
         (_, _) -> IBot
-    -- Times e1 e2 -> case (evalI e1 st, evalI e2 st) of
-    --   (Pair (a, b), Pair (c, d)) -> Pair (min ( a c) (a * d) (b * c) (b * d),  max(a * c) (a * d) (b * c) (b * d))
-    --   (_, _) -> IBot
+    Times e1 e2 -> case (evalI e1 st, evalI e2 st) of
+        (Pair (a, b), Pair (c, d)) -> 
+            let products = [a * c, a * d, b * c, b * d] in
+            Pair (minimum products, maximum products)
+        (_, _) -> IBot
     Leq _ _ -> error "Encounted leq" -- this should never happen, and be always handled by evaluateConditional
     Gte _ _ -> error "Encounted gte" -- this should never happen, and be always handled by evaluateConditional
     Eq _ _ -> error "Encountered eq" -- this should never happen, ...
@@ -172,9 +174,14 @@ refineFI e st = case e of
             Pair (a, b) -> HashMap.union (HashMap.fromList [(id, Pair (min (c - 1) a, c - 1))]) st
             _ -> HashMap.union (HashMap.fromList [(id, IBot)]) st
         (_, _) -> st -- error "Unexpected conditional"
-    Eq e1 e2 -> case (e1, evalI e2 st) of
-        (Id id, Pair (c, d)) -> HashMap.union (HashMap.fromList [(id, Pair (c, d))]) st
-        (_, _) -> st -- error "Unexpected conditional"
+    Eq e1 e2 -> case (e1, evalI e1 st, evalI e2 st) of
+        -- Only handle the trivial case, we asume e2 is just a num, and that it lies on the boundary of e1, since our intervals cannot support disjoint intervals.
+        (Id id, Pair (a, b), Pair (c, d))
+          | c /= d -> st
+          | a == c && b == c  -> HashMap.union (HashMap.fromList [(id, IBot)]) st
+          | a == c  -> HashMap.union (HashMap.fromList [(id, Pair (a+1, b))]) st
+          | b == c  -> HashMap.union (HashMap.fromList [(id, Pair (a, b-1))]) st
+          | otherwise -> st
+        (_, _, _) -> st -- error "Unexpected conditional"
     _ -> error "Unexpected case"
 ```
-

--- a/demos/StaticAnalysis/ReachingDefinitions.fix
+++ b/demos/StaticAnalysis/ReachingDefinitions.fix
@@ -1,0 +1,61 @@
+module Main where
+
+include "Common"
+
+lat RD where
+  type = RD
+  leq = rdLeq
+  join = joinRD
+  meet = meetRD
+  bot = rdBot
+
+rel RDBefore: Label, RD
+
+rule assignInit : Assign l _ _   |- RDBefore l rdBot
+rule branchInit : Branch l _ _ _ |- RDBefore l rdBot
+rule varInit    : Var l _        |- RDBefore l rdBot
+
+-- actual transfer functions
+rule assignStep :
+  Assign l x _, Seq l l', RDBefore l rd
+  |- RDBefore l' (newDefinition rd (x, l))
+
+rule branchTrue :
+  Branch l _ t _, RDBefore l rd
+  |- RDBefore t rd
+
+rule branchFalse :
+  Branch l _ _ f, RDBefore l rd
+  |- RDBefore f rd
+
+rule varStep :
+  Var l _, Seq l l', RDBefore l rd
+  |- RDBefore l' rd
+
+query stateIs: RDBefore - -
+
+```hs
+data RD = RD [(String, Label)]
+  deriving (Eq, Show, Generic)
+
+rdBot :: RD
+rdBot = RD []
+
+instance PartialOrd RD where
+  leq (RD xs) (RD ys) =
+      all (`elem` ys) xs
+
+rdLeq :: RD -> RD -> Bool
+rdLeq = leq
+
+joinRD :: RD -> RD -> RD
+joinRD (RD xs) (RD ys) =
+  RD (union xs ys)
+
+meetRD :: RD -> RD -> RD
+meetRD (RD xs) (RD ys) =
+  RD (intersect xs ys)
+
+newDefinition :: RD -> (String, Label) -> RD
+newDefinition (RD rd) (x, l) = RD ((x, l) : (filter (\(v, _) -> v /= x) rd))
+```


### PR DESCRIPTION
This PR fixes a bug in the interval analysis, specifically for the refinement for an interval in the false branch when the conditional uses ==. The previous code refined the interval to the interval that was being compared to, the correct behaviour is to trim off the ends of the interval if possible, otherwise leave the interval as is.

This PR also adds another basic analysis for reaching definitions, which finds which labels a variable may be defined from before reaching another statement.