### PR TITLE
feat: parser tuning

### DIFF
--- a/fixen.cabal
+++ b/fixen.cabal
@@ -86,6 +86,7 @@ library
                       , Fixen.Pipeline
                       , Fixen.Parser
                       , Fixen.Parser.Common
+                      , Fixen.Parser.Error
                       , Fixen.Parser.Expr
                       , Fixen.Parser.Token
                       , Fixen.Parser.Type

--- a/src/Fixen/Parser.hs
+++ b/src/Fixen/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultilineStrings #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
@@ -29,18 +30,20 @@ import Control.Applicative.Combinators (
   some,
   (<|>),
  )
+import Control.Monad
 import Control.Monad.State.Strict qualified as State
+import Data.Either
 import Data.List
 import Data.List.NonEmpty
 import Data.Map.Strict qualified as Map
 import Data.Proxy
 import Data.Set qualified as Set
 import Data.Text (Text, pack, unpack)
-import Error.Diagnose.Compat.Megaparsec (errorDiagnosticFromBundle)
 import Fixen.Fields
 import Fixen.IR.AST
 import Fixen.Monad
 import Fixen.Parser.Common
+import Fixen.Parser.Error
 import Fixen.Parser.Expr
 import Fixen.Parser.Token
 import Fixen.Parser.Type
@@ -139,7 +142,7 @@ fixenParse parser file_path file_contents = do
     Left p ->
       -- Parse failure — convert Megaparsec error bundle to a Diagnostic
       -- and fail the pass with it
-      failD $ errorDiagnosticFromBundle Nothing "syntax error" Nothing p
+      failD $ parserErrorBundleToDiagnostic Nothing p
 
 --------------------------------------------------------------------------------
 --
@@ -164,6 +167,8 @@ fixenParse parser file_path file_contents = do
 -- @since 26.7
 parseProgram :: ParserState σ => Parser σ (ModuleDeclaration, [TopLevel])
 parseProgram = do
+  -- parse any leading whitespace
+  _ <- sc
   -- Parse the module declaration (e.g. "module Foo where") and consume trailing whitespace
   mod_head <- l parseModuleDeclaration
   -- Parse all remaining top-level declarations, consuming whitespace after each
@@ -334,17 +339,80 @@ partitionTopLevels mod_decl (x : xs) = do
 --
 -- @since 26.7
 parseModuleDeclaration :: ParserState σ => Parser σ ModuleDeclaration
-parseModuleDeclaration = parsePositioned $ do
+parseModuleDeclaration = inContext "module declaration" $ parsePositioned $ do
+  -- get the starting offset so we know how to throw errors
+  start <- P.getOffset
   -- Parse the 'module' keyword (must not be indented)
   -- No need to 'try' here — module declarations are compulsory
-  _ <- l $ L.nonIndented sc $ keyword "module"
+  _ <- withNote hint1 $ L.nonIndented sc $ keyword "module"
+  -- check if it has been indented. if it has not,
+  -- either:
+  --    1. the module declaration is just the empty word 'module'
+  --    2. the module name is not indented.
+  indent1 <- P.observing indented
+  when (isLeft indent1) $ do
+    -- try parsing a module name. if it works, the user did not
+    -- indent the module name (option 2 above).
+    current_offset <- P.getOffset
+    did_write_module_name <- P.observing parseModuleName
+    offset_after_module_name <- P.getOffset
+    case did_write_module_name of
+      Left _ ->
+        -- did not write module name. option 1 is correct.
+        customErrorWithOffset start $
+          FixenCustomError
+            (Just 6)
+            ["module name"]
+            "empty module declaration"
+            [hint2]
+      Right x ->
+        -- wrote module name, but just not indented.
+        customErrorWithOffset current_offset $
+          FixenCustomError
+            (Just (offset_after_module_name - current_offset))
+            ["module name"]
+            ("unexpected '" ++ unpack (simpleIdentifier x) ++ "' at indentation 0")
+            [hint3 "module name"]
   -- Parse the module name (e.g. Data.List)
-  m <- indented *> l parseModuleName
+  m <- withNote (Hint "must be a Haskell module name") parseModuleName
+  mod_end_offset <- P.getOffset
+  indent2 <- P.observing indented
+  when (isLeft indent2) $ do
+    where_offset <- P.getOffset
+    is_where <- P.observing $ keyword "where"
+    case is_where of
+      Right _ ->
+        -- 'where' comes after, i.e., you should indent the 'where' keyword
+        customErrorWithOffset where_offset $
+          FixenCustomError
+            (Just 5)
+            []
+            "unexpected 'where' at indentation 0"
+            [hint3 "'where'"]
+      Left _ ->
+        -- it is not a where, raise an error saying that the 'where' is missing.
+
+        customErrorWithOffset start $
+          FixenCustomError
+            (Just $ mod_end_offset - start)
+            []
+            "missing 'where' at the end of module declaration"
+            [hint4]
   -- Parse the 'where' keyword
-  _ <- indented *> keyword "where"
+  _ <- withNote hint4 $ keyword "where"
   -- Allocate a fresh node ID and construct the ModuleDeclaration AST node
   i <- getNewNodeId
   return $ ModuleDeclaration i m
+  where
+    hint1 =
+      Hint
+        """
+        every program must begin with a Haskell module declaration, e.g.,
+          module MyProgram.MyModule where
+        """
+    hint2 = Hint "Haskell module name must come after 'module' keyword"
+    hint3 s = Hint $ "non-indented lines are considered new top-level declarations. indent this " ++ s ++ "."
+    hint4 = Hint "just like in Haskell, module declarations must end with a 'where'"
 
 -- ** Relation-Declaration Parser
 
@@ -388,8 +456,18 @@ parseRelationParameter
   :: ParserState σ
   => Parser σ RelationParameter
 parseRelationParameter =
-  P.try parseNamedRelationParameter
-    <|> parseUnnamedRelationParameter
+  withNote
+    ( Hint
+        """
+        relation parameters can be written via one of two forms:
+          1. named, e.g., (fieldName : MySort)
+          2. unnamed, e.g., MySort
+        sorts like MySort are arbitrary Haskell types or the name of a partial order or lattice
+        """
+    )
+    $ inContext "relation parameter"
+    $ P.try parseNamedRelationParameter
+      <|> parseUnnamedRelationParameter
 
 -- | Parses a relation declaration:
 --
@@ -419,20 +497,20 @@ parseRelationParameter =
 --
 -- @since 26.7
 parseRelation :: ParserState σ => Parser σ RelationDeclaration
-parseRelation = parsePositioned $ do
+parseRelation = inContext "relation" $ parsePositioned $ do
   -- Parse the 'rel' keyword (must not be indented)
   -- Use 'P.try' so we can backtrack when parsing top-level declarations
   _ <- P.try $ L.nonIndented sc $ keyword "rel"
   -- Verify proper indentation before the relation name
   _ <- indented
   -- Parse the capitalized relation name (relations are constructor-like)
-  rel_name <- parseCapitalizedSimpleIdentifier
+  rel_name <- withNote (Hint "relation name must start with uppercase latter, just like Haskell constructors") $ inContext "relation name" parseCapitalizedSimpleIdentifier
   -- Attempt to parse optional arguments: a colon followed by comma-separated types
   -- 'P.observing' allows backtracking — if no colon, args are empty
   colon <- P.observing $ P.try $ indented *> keywordOp ":"
   params <- case colon of
     Left _ -> return [] -- no colon — no arguments
-    Right _ -> do
+    Right _ -> inContext "relation parameter list" $ do
       -- Verify proper indentation before the first argument
       _ <- indented
       -- Parse one or more comma-separated types with indentation checking
@@ -469,7 +547,7 @@ parseRelation = parsePositioned $ do
 --
 -- @since 26.7
 parseRule :: ParserState σ => Parser σ Rule
-parseRule = parsePositioned $ do
+parseRule = inContext "rule" $ parsePositioned $ do
   -- Parse the 'rule' keyword (must not be indented)
   -- Definitely need 'try' here since rules are among many top-level alternatives
   _ <- P.try $ l $ L.nonIndented sc $ keyword "rule"
@@ -478,7 +556,10 @@ parseRule = parsePositioned $ do
   -- Parse the optional rule name and bound variables (all lowercase identifiers)
   -- If no identifiers are found, the rule is unnamed with no bound variables
   (rule_name, bound_vars) <- do
-    idents <- manyI' parseLowerFirstSimpleIdentifier
+    idents <-
+      withNote (Hint "the name and parameters of rules must start with lowercase letters") $
+        inContext "name and parameters" $
+          manyI' parseLowerFirstSimpleIdentifier
     case idents of
       [] -> return (Nothing, []) -- no identifiers — unnamed rule
       (x : xs) -> return (Just x, xs) -- first is name, rest are bound variables
@@ -543,10 +624,10 @@ partitionPremises (x : xs) =
 -- @since 26.7
 parsePremise :: ParserState σ => Parser σ RulePremise
 parsePremise =
-  -- Try assumption first (starts with capitalized identifier)
-  RPAssumption <$> parseAssumption
-    -- Fall back to condition (starts with 'if' keyword)
-    <|> RPCondition <$> parseCondition
+  -- Try condition first (starts with 'if')
+  RPCondition <$> parseCondition
+    -- Fall back to assumption
+    <|> RPAssumption <$> parseAssumption
 
 -- | Parses the conclusion of a rule: a capitalized fact name followed by
 -- zero or more expression arguments.
@@ -561,7 +642,7 @@ parsePremise =
 --
 -- @since 26.7
 parseConclusion :: ParserState σ => Parser σ Conclusion
-parseConclusion = parsePositioned $ do
+parseConclusion = inContext "conclusion" $ parsePositioned $ do
   -- Verify proper indentation before the conclusion
   _ <- indented
   -- Parse the capitalized fact name (conclusions are constructor-like)
@@ -591,17 +672,18 @@ parseConclusion = parsePositioned $ do
 --
 -- @since 26.7
 parseAssumption :: ParserState σ => Parser σ Assumption
-parseAssumption = parsePositioned $ do
+parseAssumption = inContext "premise" $ parsePositioned $ do
   -- Verify proper indentation before the assumption
   _ <- indented
   -- Parse the capitalized relation name
-  -- Use 'P.try' so we can backtrack if this is actually a condition
-  header <- P.try parseCapitalizedSimpleIdentifier
+  header <-
+    withNote (Hint "premises of rules must be valid relation names") $
+      inContext "relation name" parseCapitalizedSimpleIdentifier
   -- Verify proper indentation before the arguments
   _ <- indented
   -- Parse zero or more lowercase-starting simple identifiers as arguments.
   -- This is the **only** place that holes are accepted.
-  arguments <- manyI' parseLowerFirstSimpleIdentifierOrHole
+  arguments <- inContext "premise arguments" $ manyI' parseLowerFirstSimpleIdentifierOrHole
   -- Allocate a fresh node ID and construct the Assumption AST node
   i <- getNewNodeId
   return $ Assumption i header arguments
@@ -619,14 +701,15 @@ parseAssumption = parsePositioned $ do
 --
 -- @since 26.7
 parseCondition :: ParserState σ => Parser σ Condition
-parseCondition = parsePositioned $ do
+parseCondition = inContext "boolean condition" $ parsePositioned $ do
   -- Parse the 'if' keyword with indentation checks on both sides
   _ <-
-    indented
-      *> keyword "if"
-      *> indented
+    P.try $
+      indented
+        *> keyword "if"
+        *> indented
   -- Parse the condition expression with indentation checking
-  e <- parseExpr indented
+  e <- inContext "expression" $ parseExpr indented
   -- Allocate a fresh node ID and construct the Condition AST node
   i <- getNewNodeId
   return $ Condition i e
@@ -655,7 +738,7 @@ parseCondition = parsePositioned $ do
 --
 -- @since 26.7
 parsePartialOrd :: ParserState σ => Parser σ PartialOrdDeclaration
-parsePartialOrd = parsePositioned $ do
+parsePartialOrd = inContext "partial order" $ parsePositioned $ do
   -- Parse the 'partial' keyword (must not be indented)
   -- Need 'try' since partial ord is among many top-level alternatives
   _ <- P.try $ l $ L.nonIndented sc $ keyword "partial"
@@ -737,7 +820,7 @@ parsePartialOrdField fieldName valueParser = do
 --
 -- @since 26.7
 parseLattice :: ParserState σ => Parser σ LatticeDeclaration
-parseLattice = parsePositioned $ do
+parseLattice = inContext "lattice" $ parsePositioned $ do
   -- Parse the 'partial' keyword (must not be indented)
   -- Need 'try' since partial ord is among many top-level alternatives
   _ <- P.try $ l $ L.nonIndented sc $ keyword "lat"
@@ -784,7 +867,7 @@ parseLattice = parsePositioned $ do
 --
 -- @since 26.7
 parsePriority :: ParserState σ => Parser σ Priority
-parsePriority = parsePositioned $ do
+parsePriority = inContext "lattice" $ parsePositioned $ do
   -- Parse the 'priority' keyword (must not be indented)
   -- Need 'try' since priority is among many top-level alternatives
   _ <- P.try $ l $ L.nonIndented sc $ keyword "priority"
@@ -906,7 +989,7 @@ parseSubstitution = do
 --
 -- @since 26.7
 parseQuery :: ParserState σ => Parser σ Query
-parseQuery = parsePositioned $ do
+parseQuery = inContext "query" $ parsePositioned $ do
   -- Parse the 'query' keyword (must not be indented)
   -- Need 'try' since query is among many top-level alternatives
   _ <- P.try $ l $ L.nonIndented sc $ keyword "query"
@@ -979,7 +1062,7 @@ parseQueryMode = parsePositioned $ do
 --
 -- @since 26.7
 parseInclude :: ParserState σ => Parser σ Include
-parseInclude = parsePositioned $ do
+parseInclude = inContext "include" $ parsePositioned $ do
   -- Parse the 'include' keyword (must not be indented)
   -- Need 'try' since include is among many top-level alternatives
   _ <- P.try $ l $ L.nonIndented sc $ keyword "include"
@@ -1036,7 +1119,7 @@ parseImportSpecs = pack <$> parens
 --
 -- @since 26.7
 parseImport :: ParserState σ => Parser σ HsImport
-parseImport = parsePositioned $ do
+parseImport = inContext "import" $ parsePositioned $ do
   -- Parse the 'import' keyword (must not be indented)
   -- Need 'try' since import is among many top-level alternatives
   _ <- P.try $ l $ L.nonIndented sc $ keyword "import"
@@ -1104,7 +1187,7 @@ parseImport = parsePositioned $ do
 --
 -- @since 26.7
 parsePhases :: ParserState σ => Parser σ PhasesDeclaration
-parsePhases = parsePositioned $ do
+parsePhases = inContext "phases" $ parsePositioned $ do
   -- Parse the 'phases' keyword (must not be indented)
   -- No 'try' needed — phases is the last syntactic category
   _ <- L.nonIndented sc $ keyword "phases"
@@ -1184,7 +1267,7 @@ parseEverythingElseRuleset = parsePositioned $ do
 --
 -- @since 26.7
 parseHaskellCodeBlock :: ParserState σ => Parser σ HsBlock
-parseHaskellCodeBlock = parsePositioned $ do
+parseHaskellCodeBlock = inContext "inline Haskell" $ parsePositioned $ do
   -- Parse the opening fence (```hs) — must not be indented
   -- Use 'try' since Haskell blocks are among many top-level alternatives
   _ <- P.try $ L.nonIndented sc $ keyword "```hs"

--- a/src/Fixen/Parser/Common.hs
+++ b/src/Fixen/Parser/Common.hs
@@ -36,14 +36,13 @@ module Fixen.Parser.Common where
 
 import Control.Monad.State.Strict
 import Data.List.NonEmpty
-import Data.Set (Set)
 import Data.Text
 import Data.Void
 import Error.Diagnose.Compat.Megaparsec
 import Fixen.Fields
 import Fixen.IR.AST
 import Fixen.Monad
-import Text.Megaparsec (ErrorFancy, ErrorItem)
+import Fixen.Parser.Error
 import Text.Megaparsec qualified as P
 import Text.Megaparsec.Char qualified as C
 import Text.Megaparsec.Char.Lexer qualified as L
@@ -54,21 +53,6 @@ import Text.Megaparsec.Pos qualified as MPos
 -- * Parsers and Parser States
 
 --------------------------------------------------------------------------------
-
--- | A custom parser error datatype.
-data FixenParserError
-  = TrivialWithParseStack
-      [String]
-      -- ^ The non-terminal stack
-      (Maybe (ErrorItem Text))
-      -- ^ The unexpected item
-      (Set (ErrorItem Char))
-  | FancyWithParseStack
-      [String]
-      -- ^ The non-terminal stack
-      (ErrorFancy Void)
-      -- ^ The fancy error
-  deriving (Eq, Ord, Show)
 
 -- | The state carried by the parser.
 --
@@ -89,16 +73,15 @@ type ParserState σ = (WithPositionEnv σ, NodeIded σ, WithErrors σ)
 --   This is a Megaparsec parser ('P.ParsecT') layered on top of the 'State'
 --   monad.
 --
---   The 'Void' error token means this parser does not produce token-level
---   parse errors (all errors are handled at a higher level via the
---   'FixenErrors' accumulator).
+--   The parser type uses the custom 'FixenParseError' datatype. Internally,
+--   throughout parsing, all errors are represented using this custom datatype.
 --
 --   In practice, you will rarely construct values of type 'Parser' directly.
 --   Instead, use the combinators provided in this module and the higher-level
 --   parsers in 'Fixen.Parser'.
 --
 -- @since 26.7
-type Parser σ = P.ParsecT Void Text (State σ)
+type Parser σ = P.ParsecT FixenParseError Text (State σ)
 
 --------------------------------------------------------------------------------
 

--- a/src/Fixen/Parser/Error.hs
+++ b/src/Fixen/Parser/Error.hs
@@ -1,0 +1,449 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- |
+--     Module      : Fixen.Parser.Error
+--     Description : Custom error datatype for the Fixen parser.
+--     Copyright   : (c) Programming Languages Innovation Lab@NUS
+--     License     : MIT
+--     Maintainer  : yongqi@nus.edu.sg
+--     Stability   : experimental
+--
+--     This module provides utilities for Fixen parser errors.
+--
+-- @since 26.8
+module Fixen.Parser.Error where
+
+import Data.List
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Maybe
+import Data.Proxy (Proxy (..))
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Void
+import Error.Diagnose (
+  Diagnostic,
+  Marker (..),
+  Note (..),
+  Position (..),
+  Report (..),
+  addReport,
+ )
+import Text.Megaparsec (
+  ErrorFancy (..),
+  ErrorItem (..),
+  MonadParsec (..),
+  ParseError (..),
+  ParseErrorBundle (..),
+  Pos,
+  Token,
+  pstateSourcePos,
+  reachOffset,
+  region,
+  showErrorItem,
+  sourceColumn,
+  sourceLine,
+  sourceName,
+  tokensLength,
+  unPos,
+ )
+
+--------------------------------------------------------------------------------
+
+-- * Main Types
+
+--------------------------------------------------------------------------------
+
+-- | The type of parse stacks. Ordered bottom-up, i.e., the first
+-- element of the list is the bottom-most stack frame. If viewed as a top-down
+-- parser, reading this list from left to right is essentially reading from
+-- top down the parse tree.
+type ParseStack = [Nonterminal]
+
+-- | Nonterminal symbols are just strings.
+type Nonterminal = String
+
+-- | A custom parser error datatype. Mirrors 'ParseError', except with
+-- additional bookkeeping data.
+--
+-- @since 26.8
+data FixenParseError
+  = FixenTrivialParseError
+      (Maybe (ErrorItem (Token Text)))
+      -- ^ The unexpected tokens, if any
+      (Set (ErrorItem (Token Text)))
+      -- ^ The expected tokens
+      ParseStack
+      -- ^ The parse stack
+      [Note String]
+      -- ^ A list of hints
+  | FixenIndentationError
+      Ordering
+      -- ^ The ordering
+      Pos
+      -- ^ Reference Level
+      Pos
+      -- ^ Actual level
+      ParseStack
+      -- ^ The parse stack
+      [Note String]
+      -- ^ A list of hints
+  | FixenCustomError
+      (Maybe Int)
+      -- ^ A potential token length
+      ParseStack
+      -- ^ The parse stack
+      String
+      -- ^ The error message
+      [Note String]
+      -- ^ A list of hints
+  deriving (Eq, Ord, Show)
+
+--------------------------------------------------------------------------------
+
+-- * Dealing with Parser Errors
+
+-- $parserErrors
+-- Megaparsec defaults are generally not sufficient for detailed error reporting.
+-- To endow the default errors with more information, you have the following
+-- options:
+-- 1. 'withNote' allows you to add custom 'Note's to errors emitted from a parser
+-- 2. 'inContext' allows you to add a stack frame to errors emitted from a parser
+-- 3. 'customErrorWithOffset' is similar to 'Text.Megaparsec.customError',
+--    except that you can specify the starting offset of the error.
+
+--------------------------------------------------------------------------------
+
+-- | Adds a 'Note' to error(s) emitted from a parser.
+--
+-- @since 26.8
+withNote
+  :: MonadParsec FixenParseError Text m
+  => Note String
+  -- ^ The note to add
+  -> m a
+  -- ^ The parser
+  -> m a
+withNote x = region (addNote x)
+
+-- | Adds a 'Nonterminal' (stack frame) to the 'ParseStack' of the error(s)
+-- emitted from a parser.
+--
+-- @since 26.8
+inContext :: MonadParsec FixenParseError Text m => Nonterminal -> m a -> m a
+inContext x = region (prependFrame x)
+
+-- | Throws a 'FixenCustomError' with a given offset.
+-- Essentially the same as 'Text.Megaparsec.customError'.
+--
+-- @since 26.8
+customErrorWithOffset
+  :: MonadParsec e s m
+  => Int
+  -- ^ The offset
+  -> e
+  -- ^ The custom error
+  -> m a
+customErrorWithOffset start = parseError . FancyError start . Set.singleton . ErrorCustom
+
+--------------------------------------------------------------------------------
+
+-- * Interop with Diagnose
+
+--------------------------------------------------------------------------------
+
+-- | A modification to 'Error.Diagnose.Compat.Megaparsec.diagnosticFromBundle'.
+-- It converts Megaparsec errors and 'FixenParserError's into well-formatted
+-- 'Diagnostic's ready to be shown.
+--
+-- @since 26.8
+parserErrorBundleToDiagnostic
+  :: Maybe String
+  -- ^ An optional error code
+  -> ParseErrorBundle Text FixenParseError
+  -- ^ The bundle to create a diagnostic from
+  -> Diagnostic String
+parserErrorBundleToDiagnostic code ParseErrorBundle {..} =
+  foldl addReport mempty (asReport . normalizeParseError <$> bundleErrors)
+  where
+    asReport :: ParseError Text FixenParseError -> Report String
+    asReport e@(FancyError start errs) =
+      let real_errs = customErrors errs
+          parse_stack = getParseStack e
+          parse_stack_msg = parseStackMessage parse_stack
+       in case real_errs of
+            [] -> error "parse error is empty"
+            [x] ->
+              let err_len = parseErrorTokenLength x
+                  err_pos = getPositionFromOffsets start err_len
+                  err_msg = parseErrorMessage x
+                  err_notes = parseErrorNotes x
+               in Err
+                    code
+                    "syntax error"
+                    [(err_pos, This err_msg)]
+                    (parse_stack_msg ++ err_notes)
+            xs ->
+              let package =
+                    ( \(i, x) ->
+                        let err_len = parseErrorTokenLength x
+                            err_pos = getPositionFromOffsets start err_len
+                            err_msg = parseErrorMessage x
+                            err_notes = parseErrorNotes x
+                         in ( [(err_pos, This $ withErrorNumber i err_msg)]
+                            , fmap (fmap (withErrorNumber i)) err_notes
+                            )
+                    )
+                      <$> Prelude.zip [1 .. Prelude.length xs] xs
+                  (markers, notes) =
+                    foldl'
+                      (\(x1, x2) (y1, y2) -> (x1 ++ y1, x2 ++ y2))
+                      ([], [])
+                      package
+               in Err code "syntax error" markers (parse_stack_msg ++ notes)
+    asReport _ = error "unreachable" -- impossible after normalization
+    withErrorNumber :: Int -> String -> String
+    withErrorNumber i s = show i ++ ". " ++ s
+
+    customErrors :: Set (ErrorFancy FixenParseError) -> [FixenParseError]
+    customErrors s =
+      mapMaybe (\case ErrorCustom x -> Just x; _ -> Nothing) $
+        Set.toList s
+    getPositionFromOffsets :: Int -> Int -> Position
+    getPositionFromOffsets start len =
+      let (_, pos) = reachOffset start bundlePosState
+          src_start = pstateSourcePos pos
+          (_, pos') = reachOffset (start + len) pos
+          src_end = pstateSourcePos pos'
+          file_name = sourceName src_start
+          startPos =
+            both'
+              (fromIntegral . unPos)
+              (sourceLine src_start, sourceColumn src_start)
+          endPos =
+            both'
+              (fromIntegral . unPos)
+              (sourceLine src_end, sourceColumn src_end)
+       in Position startPos endPos file_name
+    both' :: (a -> b) -> (a, a) -> (b, b)
+    both' f ~(x, y) = (f x, f y)
+
+--------------------------------------------------------------------------------
+
+-- * Helpers
+
+--------------------------------------------------------------------------------
+
+-- | Obtains the error message from a 'FixenParseError'
+--
+-- @since 26.8
+parseErrorMessage :: FixenParseError -> String
+-- On trivial parse errors, the expected tokens are found in the notes/hints,
+-- see parseErrorNotes.
+parseErrorMessage (FixenTrivialParseError Nothing _ _ _) = "unknown parse error"
+parseErrorMessage (FixenTrivialParseError _ ex _ _) | Set.null ex = "unknown parse error"
+parseErrorMessage (FixenTrivialParseError (Just unex) _ _ _) = "unexpected " ++ showErrorItem textProxy unex
+parseErrorMessage (FixenIndentationError {}) = "incorrect indentation"
+parseErrorMessage (FixenCustomError _ _ msg _) = msg
+
+-- | Obtains the 'Note's from a 'FixenParseError'.
+--
+-- @since 26.8
+parseErrorNotes :: FixenParseError -> [Note String]
+parseErrorNotes (FixenTrivialParseError _ ex _ hs) =
+  let expected_msg =
+        [ Note $
+            "expecting "
+              ++ (orList . NonEmpty.fromList . Set.toAscList)
+                (showErrorItem textProxy `Set.map` ex)
+        | not $ Set.null ex
+        ]
+   in expected_msg ++ hs
+  where
+    -- straight plagiarized from Megaparsec
+    orList :: NonEmpty String -> String
+    orList (x :| []) = x
+    orList (x :| [y]) = x <> " or " <> y
+    orList xs = intercalate ", " (NonEmpty.init xs) <> ", or " <> NonEmpty.last xs
+parseErrorNotes (FixenIndentationError o ref act _ hs) =
+  -- essentially plagiarized from Megaparsec
+  Note
+    ( "got "
+        ++ Prelude.show (unPos act)
+        ++ ", should be "
+        ++ p
+        ++ Prelude.show (unPos ref)
+        ++ ")"
+    )
+    : hs
+  where
+    p = case o of LT -> "less than "; EQ -> "equal to "; GT -> "greater than "
+parseErrorNotes (FixenCustomError _ _ msg h) = Note msg : h
+
+-- | Converts a 'ParseStack' trace into 'Note's.
+--
+-- @since 26.8
+parseStackMessage :: ParseStack -> [Note String]
+parseStackMessage [] = []
+parseStackMessage stack =
+  [ Note $
+      "error occurred while parsing " ++ intercalate ", " stack
+  ]
+
+-- | Obtains the token length from a 'FixenParseError'.
+--
+-- @since 26.8
+parseErrorTokenLength :: FixenParseError -> Int
+parseErrorTokenLength (FixenTrivialParseError (Just (Tokens unex)) _ _ _) =
+  tokensLength textProxy unex
+parseErrorTokenLength (FixenCustomError (Just i) _ _ _) = i
+parseErrorTokenLength _ = 1 -- default value, uninteresting
+
+-- | Gets the parse stack from parse errors. This crashes
+-- when errors have different non-empty call stacks.
+--
+-- @since 26.8
+getParseStack :: ParseError Text FixenParseError -> [String]
+getParseStack (TrivialError {}) = []
+getParseStack (FancyError _ s) =
+  let stacks =
+        Set.map
+          ( \case
+              ErrorCustom (FixenTrivialParseError _ _ st _) -> st
+              ErrorCustom (FixenIndentationError _ _ _ st _) -> st
+              ErrorCustom (FixenCustomError _ st _ _) -> st
+              _ -> []
+          )
+          s
+      nonempty_stacks = Set.filter (not . Prelude.null) stacks
+   in if
+        | Set.size nonempty_stacks > 1 -> error "parse errors at the same parse point has different parse stacks!"
+        | Set.null nonempty_stacks -> []
+        | otherwise -> Set.elemAt 0 nonempty_stacks
+
+-- | Prepends a 'Nonterminal' onto a parse error.
+--
+-- @since 26.8
+prependFrame
+  :: Nonterminal
+  -- ^ The nonterminal to prepend
+  -> ParseError Text FixenParseError
+  -- ^ The error
+  -> ParseError Text FixenParseError
+prependFrame s e =
+  let e' = normalizeParseError e
+   in case e' of
+        FancyError i errs ->
+          FancyError i $
+            Set.map
+              ( \case
+                  ErrorCustom (FixenTrivialParseError unex ex st h) ->
+                    ErrorCustom (FixenTrivialParseError unex ex (s : st) h)
+                  ErrorCustom (FixenIndentationError o p1 p2 st h) ->
+                    ErrorCustom (FixenIndentationError o p1 p2 (s : st) h)
+                  ErrorCustom (FixenCustomError start st msg h) ->
+                    ErrorCustom (FixenCustomError start (s : st) msg h)
+                  x -> x
+              )
+              errs
+        x -> x
+
+-- | Adds a note to a parse error.
+--
+-- @since 26.8
+addNote
+  :: Note String
+  -- ^ The note to add
+  -> ParseError Text FixenParseError
+  -- ^ The parse error
+  -> ParseError Text FixenParseError
+addNote note e =
+  let e' = normalizeParseError e
+   in case e' of
+        FancyError i errs ->
+          FancyError i $
+            Set.map
+              ( \case
+                  ErrorCustom (FixenTrivialParseError unex ex st h) -> ErrorCustom (FixenTrivialParseError unex ex st (note : h))
+                  ErrorCustom (FixenIndentationError o p1 p2 st h) -> ErrorCustom (FixenIndentationError o p1 p2 st (note : h))
+                  ErrorCustom (FixenCustomError start st msg h) -> ErrorCustom (FixenCustomError start st msg (note : h))
+                  x -> x
+              )
+              errs
+        x -> x
+
+-- | Normalizes parse errors emitted from megaparsec (and Fixen) into a
+-- canonical form which we can work with. Essentially, all megaparsec-emitted
+-- errors are stored as 'FixenCustomError's. Merging errors from alternatives
+-- behaves as we would normally expect. This crashes whenever errors have
+-- different non-empty stack traces.
+--
+-- @since 26.8
+normalizeParseError :: ParseError Text FixenParseError -> ParseError Text FixenParseError
+normalizeParseError (TrivialError i m s) =
+  -- just convert it into a FixenTrivialParseError
+  FancyError i . Set.singleton . ErrorCustom $ FixenTrivialParseError m s [] []
+normalizeParseError err@(FancyError i s) =
+  -- we need to do a proper merging of FixenTrivialParseErrors like we do for
+  -- megaparsec's TrivialErrors.
+  let (trivials, nontrivials) =
+        Set.partition
+          ( \case
+              ErrorCustom (FixenTrivialParseError {}) -> True
+              _ -> False
+          )
+          s
+      -- get the parse stack
+      parse_stack = getParseStack err
+      -- convert the nontrivial errors into FixenCustomErrors
+      converted_nontrivials =
+        Set.map
+          ( \case
+              ErrorFail msg ->
+                ErrorCustom $
+                  FixenCustomError Nothing parse_stack msg []
+              ErrorIndentation o p1 p2 ->
+                ErrorCustom $
+                  FixenIndentationError o p1 p2 parse_stack []
+              e -> e
+          )
+          nontrivials
+      -- we are lazy. so, we're going to merge trivial errors using megaparsec's
+      -- TrivialError semigroup capabilities
+      base_trivials =
+        ( \case
+            ErrorCustom (FixenTrivialParseError m ss _ _) ->
+              TrivialError @Text @Void i m ss
+            _ -> error "unreachable"
+        )
+          <$> Set.toList trivials
+      -- get the (unique) notes we have added to any of these trivial errors
+      trivials_notes =
+        nub $
+          concatMap
+            ( \case
+                ErrorCustom (FixenTrivialParseError _ _ _ h) -> h
+                _ -> error "unreachable"
+            )
+            (Set.toList trivials)
+      -- combine the trivial errors using <>
+      combined_trivials = case base_trivials of
+        [] -> Set.empty
+        (x : xs) -> case Prelude.foldl' (<>) x xs of
+          -- map them back to FixenTrivialParseErrors
+          TrivialError _ m ss ->
+            Set.singleton . ErrorCustom $
+              FixenTrivialParseError m ss parse_stack trivials_notes
+          _ -> error "unreachable"
+   in if not $ Set.null converted_nontrivials
+        then FancyError i converted_nontrivials -- prefer nontrivials
+        else FancyError i combined_trivials
+
+-- | Quite possibly the most uninteresting thing you will find.
+--
+-- @since 26.8
+textProxy :: Proxy Text
+textProxy = Proxy

--- a/src/Fixen/Parser/Token.hs
+++ b/src/Fixen/Parser/Token.hs
@@ -143,7 +143,6 @@ parseRawLowerHsIdentifierString = do
         -- Reject the parse if the resulting string matches a reserved keyword
   if str `elem` reserved
     then -- emit a parse error indicating the keyword was unexpected
-
       P.parseError
         ( P.FancyError
             offset_start
@@ -183,7 +182,6 @@ parseRawLowerHsIdentifierStringOrHole = do
         -- Reject the parse if the resulting string matches a reserved keyword
   if str `elem` reserved
     then -- emit a parse error indicating the keyword was unexpected
-
       P.parseError
         ( P.FancyError
             offset_start
@@ -235,7 +233,6 @@ parseRawAnyCaseHsIdentifierString = do
         -- Reject if the string matches a reserved keyword
   if str `elem` reserved
     then -- emit a parse error for the reserved keyword
-
       P.parseError
         ( P.FancyError
             offset_start
@@ -273,7 +270,6 @@ parseRawAnyCaseHsIdentifierStringNotHole = do
         -- Reject if the string matches a reserved keyword
   if str `elem` reserved
     then -- emit a parse error for the reserved keyword
-
       P.parseError
         ( P.FancyError
             offset_start
@@ -318,7 +314,6 @@ parseRawOpIdentifierString = do
   -- Reject if the string matches a reserved operator
   if str `elem` reservedOps
     then -- emit a parse error for the reserved operator
-
       P.parseError
         ( P.FancyError
             offset_start


### PR DESCRIPTION
related to issue #7 
added custom-error facilities to the parser. now we can add parse-stack traces and custom notes or customize the token lengths of reported parse errors