### PR TITLE
Allow Haskel versions up to 9.14.1 and base versions up to 4.22.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This is an example of how you may give instructions on setting up your project l
 To get a local copy up and running follow these simple example steps.
 
 ### Prerequisites
-- [GHC](https://www.haskell.org/ghc/) v9.12.2 (base v4.21.0.0)
+- [GHC](https://www.haskell.org/ghc/) v9.12.2-9.14.1 (base v4.21.0.0-v4.22.0.0)
 - [Cabal](https://www.haskell.org/cabal/) v3.16.0.0
 - HLS v2.14.0.0
 - git

--- a/fixen.cabal
+++ b/fixen.cabal
@@ -46,7 +46,7 @@ library diagnose
                         , LambdaCase
                         , BlockArguments
     build-depends:        array==0.5.8.0
-                        , base==4.21.0.0
+                        , base>=4.21.0.0 && <= 4.22.0.0
                         , containers==0.8
                         , data-default==0.8.0.2
                         , dlist==1.0
@@ -105,7 +105,8 @@ library
                       , Fixen.SymbolSolver.Rule
                       , Fixen.SymbolSolver.Validation
                       , Fixen.Utils
-    build-depends:      base==4.21.0.0
+    build-depends:      
+                        base>=4.21.0.0 && <= 4.22.0.0
                       , base-unicode-symbols==0.2.4.2
                       , containers==0.8
                       , directory==1.3.10.1


### PR DESCRIPTION
Allows base versions v4.21.0.0 to 4.22.0.0 in the cabal file and update README to allow Haskell versions 9.12.2 to 9.14.1